### PR TITLE
[WIP] Allow for `Column<Any>` usage inside lookups

### DIFF
--- a/src/circuit/floor_planner/single_pass.rs
+++ b/src/circuit/floor_planner/single_pass.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -425,8 +426,8 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
         let mut value = None;
         self.cs.assign_fixed(
             annotation,
-            column.inner(),
-            offset, // tables are always assigned starting at row 0
+            column.inner().try_into().unwrap(), // TODO: Handle correctly!!!
+            offset,                             // tables are always assigned starting at row 0
             || {
                 let res = to();
                 value = res.as_ref().ok().cloned();

--- a/src/circuit/floor_planner/v1.rs
+++ b/src/circuit/floor_planner/v1.rs
@@ -334,9 +334,12 @@ impl<'p, 'a, F: Field, CS: Assignment<F> + 'a> AssignmentPass<'p, 'a, F, CS> {
             // default_val must be Some because we must have assigned
             // at least one cell in each column, and in that case we checked
             // that all cells up to first_unused were assigned.
-            self.plan
-                .cs
-                .fill_from_row(col.inner(), first_unused, default_val.unwrap())?;
+            self.plan.cs.fill_from_row(
+                // TODO: Handle correctly!!!
+                col.inner(),
+                first_unused,
+                default_val.unwrap(),
+            )?;
         }
 
         Ok(result)

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -485,7 +485,7 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
 
     fn fill_from_row(
         &mut self,
-        _: Column<Fixed>,
+        _: Column<Any>,
         from_row: usize,
         _: Option<Assigned<F>>,
     ) -> Result<(), Error> {

--- a/src/dev/cost.rs
+++ b/src/dev/cost.rs
@@ -110,7 +110,7 @@ impl<F: Field> Assignment<F> for Assembly {
 
     fn fill_from_row(
         &mut self,
-        _: Column<Fixed>,
+        _: Column<Any>,
         _: usize,
         _: Option<Assigned<F>>,
     ) -> Result<(), Error> {

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -146,7 +146,7 @@ impl<F: Field> Assignment<F> for Assembly<F> {
 
     fn fill_from_row(
         &mut self,
-        column: Column<Fixed>,
+        column: Column<Any>,
         from_row: usize,
         to: Option<Assigned<F>>,
     ) -> Result<(), Error> {

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -240,7 +240,7 @@ pub fn create_proof<
 
                 fn fill_from_row(
                     &mut self,
-                    _: Column<Fixed>,
+                    _: Column<Any>,
                     _: usize,
                     _: Option<Assigned<F>>,
                 ) -> Result<(), Error> {

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -6,8 +6,8 @@ use halo2::circuit::{Cell, Layouter, SimpleFloorPlanner};
 use halo2::dev::MockProver;
 use halo2::pasta::{Eq, EqAffine, Fp};
 use halo2::plonk::{
-    create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column, ConstraintSystem,
-    Error, Fixed, TableColumn, VerifyingKey,
+    create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Any, Circuit, Column,
+    ConstraintSystem, Error, Fixed, TableColumn, VerifyingKey,
 };
 use halo2::poly::{commitment::Params, Rotation};
 use halo2::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
@@ -270,7 +270,10 @@ fn plonk_api() {
             let sb = meta.fixed_column();
             let sc = meta.fixed_column();
             let sp = meta.fixed_column();
-            let sl = meta.lookup_table_column();
+            let sl = meta.lookup_table_column(Any::Fixed);
+            // If we don't pass a `Fixed` type here, it fails
+            // since the FloorPlanner tries to convert any type of
+            // column into a fixed one when calling `assing_cell`.
 
             /*
              *   A         B      ...  sl


### PR DESCRIPTION
WIP towards #4

Currently doesn't work since the `SimpleFloorPlanner` requires in the `assign_cell` fn to assing either fixed or advice the column. And since we allocate it as `Any`, we are forced to do a conversion which can fail. Therefore it only works now if you:

- Allocate an `Advice` column and use `assing_advice` inside `assign_cell`.
- Allocate a `Fixed` column and use `assign_fixed` inside `assign_cell` (current code pushed).