### PR TITLE
use Rotation to sort the opening points s.t. the ordering is static

### DIFF
--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -517,26 +517,31 @@ impl<C: CurveAffine> Evaluated<C> {
             // Open lookup product commitments at x
             .chain(Some(ProverQuery {
                 point: *x,
+                rotation: Rotation::cur(),
                 poly: &self.constructed.product_poly,
             }))
             // Open lookup input commitments at x
             .chain(Some(ProverQuery {
                 point: *x,
+                rotation: Rotation::cur(),
                 poly: &self.constructed.permuted_input_poly,
             }))
             // Open lookup table commitments at x
             .chain(Some(ProverQuery {
                 point: *x,
+                rotation: Rotation::cur(),
                 poly: &self.constructed.permuted_table_poly,
             }))
             // Open lookup input commitments at x_inv
             .chain(Some(ProverQuery {
                 point: x_inv,
+                rotation: Rotation::prev(),
                 poly: &self.constructed.permuted_input_poly,
             }))
             // Open lookup product commitments at x_next
             .chain(Some(ProverQuery {
                 point: x_next,
+                rotation: Rotation::next(),
                 poly: &self.constructed.product_poly,
             }))
     }

--- a/halo2_proofs/src/plonk/lookup/verifier.rs
+++ b/halo2_proofs/src/plonk/lookup/verifier.rs
@@ -178,30 +178,35 @@ impl<C: CurveAffine> Evaluated<C> {
             .chain(Some(VerifierQuery::new_commitment(
                 &self.committed.product_commitment,
                 *x,
+                Rotation::cur(),
                 self.product_eval,
             )))
             // Open lookup input commitments at x
             .chain(Some(VerifierQuery::new_commitment(
                 &self.committed.permuted.permuted_input_commitment,
                 *x,
+                Rotation::cur(),
                 self.permuted_input_eval,
             )))
             // Open lookup table commitments at x
             .chain(Some(VerifierQuery::new_commitment(
                 &self.committed.permuted.permuted_table_commitment,
                 *x,
+                Rotation::cur(),
                 self.permuted_table_eval,
             )))
             // Open lookup input commitments at \omega^{-1} x
             .chain(Some(VerifierQuery::new_commitment(
                 &self.committed.permuted.permuted_input_commitment,
                 x_inv,
+                Rotation::prev(),
                 self.permuted_input_inv_eval,
             )))
             // Open lookup product commitment at \omega x
             .chain(Some(VerifierQuery::new_commitment(
                 &self.committed.product_commitment,
                 x_next,
+                Rotation::next(),
                 self.product_next_eval,
             )))
     }

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -308,9 +308,11 @@ impl<C: CurveAffine> super::ProvingKey<C> {
         &self,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'_, C>> + Clone {
-        self.polys
-            .iter()
-            .map(move |poly| ProverQuery { point: *x, poly })
+        self.polys.iter().map(move |poly| ProverQuery {
+            point: *x,
+            rotation: Rotation::cur(),
+            poly,
+        })
     }
 
     pub(in crate::plonk) fn evaluate<E: EncodedChallenge<C>, T: TranscriptWrite<C, E>>(
@@ -393,10 +395,12 @@ impl<C: CurveAffine> Evaluated<C> {
                     // Open permutation product commitments at x and \omega x
                     .chain(Some(ProverQuery {
                         point: *x,
+                        rotation: Rotation::cur(),
                         poly: &set.permutation_product_poly,
                     }))
                     .chain(Some(ProverQuery {
                         point: x_next,
+                        rotation: Rotation::next(),
                         poly: &set.permutation_product_poly,
                     }))
             }))
@@ -412,6 +416,7 @@ impl<C: CurveAffine> Evaluated<C> {
                     .flat_map(move |set| {
                         Some(ProverQuery {
                             point: x_last,
+                            rotation: Rotation(-((blinding_factors + 1) as i32)),
                             poly: &set.permutation_product_poly,
                         })
                     }),

--- a/halo2_proofs/src/plonk/permutation/verifier.rs
+++ b/halo2_proofs/src/plonk/permutation/verifier.rs
@@ -218,11 +218,13 @@ impl<C: CurveAffine> Evaluated<C> {
                     .chain(Some(VerifierQuery::new_commitment(
                         &set.permutation_product_commitment,
                         *x,
+                        Rotation::cur(),
                         set.permutation_product_eval,
                     )))
                     .chain(Some(VerifierQuery::new_commitment(
                         &set.permutation_product_commitment,
                         x_next,
+                        Rotation::next(),
                         set.permutation_product_next_eval,
                     )))
             }))
@@ -231,6 +233,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 Some(VerifierQuery::new_commitment(
                     &set.permutation_product_commitment,
                     x_last,
+                    Rotation(-((blinding_factors + 1) as i32)),
                     set.permutation_product_last_eval.unwrap(),
                 ))
             }))
@@ -247,6 +250,8 @@ impl<C: CurveAffine> CommonEvaluated<C> {
         vkey.commitments
             .iter()
             .zip(self.permutation_evals.iter())
-            .map(move |(commitment, &eval)| VerifierQuery::new_commitment(commitment, *x, eval))
+            .map(move |(commitment, &eval)| {
+                VerifierQuery::new_commitment(commitment, *x, Rotation::cur(), eval)
+            })
     }
 }

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -663,6 +663,7 @@ pub fn create_proof<
                         .iter()
                         .map(move |&(column, at)| ProverQuery {
                             point: domain.rotate_omega(*x, at),
+                            rotation: at,
                             poly: &instance.instance_polys[column.index()],
                         }),
                 )
@@ -673,6 +674,7 @@ pub fn create_proof<
                         .iter()
                         .map(move |&(column, at)| ProverQuery {
                             point: domain.rotate_omega(*x, at),
+                            rotation: at,
                             poly: &advice.advice_polys[column.index()],
                         }),
                 )
@@ -686,6 +688,7 @@ pub fn create_proof<
                 .iter()
                 .map(|&(column, at)| ProverQuery {
                     point: domain.rotate_omega(*x, at),
+                    rotation: at,
                     poly: &pk.fixed_polys[column.index()],
                 }),
         )

--- a/halo2_proofs/src/plonk/vanishing/prover.rs
+++ b/halo2_proofs/src/plonk/vanishing/prover.rs
@@ -5,6 +5,7 @@ use group::Curve;
 use rand_core::RngCore;
 
 use super::Argument;
+use crate::poly::Rotation;
 use crate::{
     arithmetic::{eval_polynomial, CurveAffine, FieldExt},
     plonk::{ChallengeX, ChallengeY, Error},
@@ -138,10 +139,12 @@ impl<C: CurveAffine> Evaluated<C> {
         iter::empty()
             .chain(Some(ProverQuery {
                 point: *x,
+                rotation: Rotation::cur(),
                 poly: &self.h_poly,
             }))
             .chain(Some(ProverQuery {
                 point: *x,
+                rotation: Rotation::cur(),
                 poly: &self.committed.random_poly,
             }))
     }

--- a/halo2_proofs/src/plonk/vanishing/verifier.rs
+++ b/halo2_proofs/src/plonk/vanishing/verifier.rs
@@ -2,6 +2,7 @@ use std::iter;
 
 use ff::Field;
 
+use crate::poly::Rotation;
 use crate::{
     arithmetic::CurveAffine,
     plonk::{Error, VerifyingKey},
@@ -124,11 +125,13 @@ impl<'params, C: CurveAffine> Evaluated<C> {
             .chain(Some(VerifierQuery::new_msm(
                 &self.h_commitment,
                 *x,
+                Rotation::cur(),
                 self.expected_h_eval,
             )))
             .chain(Some(VerifierQuery::new_commitment(
                 &self.random_poly_commitment,
                 *x,
+                Rotation::cur(),
                 self.random_eval,
             )))
     }

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -345,6 +345,7 @@ pub fn verify_proof<
                             VerifierQuery::new_commitment(
                                 &instance_commitments[column.index()],
                                 vk.domain.rotate_omega(*x, at),
+                                at,
                                 instance_evals[query_index],
                             )
                         },
@@ -354,6 +355,7 @@ pub fn verify_proof<
                             VerifierQuery::new_commitment(
                                 &advice_commitments[column.index()],
                                 vk.domain.rotate_omega(*x, at),
+                                at,
                                 advice_evals[query_index],
                             )
                         },
@@ -376,6 +378,7 @@ pub fn verify_proof<
                     VerifierQuery::new_commitment(
                         &vk.fixed_commitments[column.index()],
                         vk.domain.rotate_omega(*x, at),
+                        at,
                         fixed_evals[query_index],
                     )
                 }),

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -254,7 +254,7 @@ impl<'a, F: Field, B: Basis> Mul<F> for Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Rotation(pub i32);
 
 impl Rotation {

--- a/halo2_proofs/src/poly/multiopen.rs
+++ b/halo2_proofs/src/poly/multiopen.rs
@@ -347,7 +347,7 @@ mod tests {
                     {
                         let poly = &polynomials[i][j];
                         let commitment: &G1Affine = &commitments[i][j];
-                        let eval = eval_polynomial(&poly, *point);
+                        let eval = eval_polynomial(poly, *point);
                         let query = VerifierQuery::new_commitment(commitment, *point, *rot, eval);
                         verifier_queries.push(query);
                     }

--- a/halo2_proofs/src/poly/multiopen/gwc.rs
+++ b/halo2_proofs/src/poly/multiopen/gwc.rs
@@ -17,6 +17,7 @@ use std::{
     marker::PhantomData,
 };
 
+use crate::poly::Rotation;
 pub use prover::create_proof;
 pub use verifier::verify_proof;
 
@@ -38,22 +39,22 @@ fn construct_intermediate_sets<F: FieldExt, I, Q: Query<F>>(queries: I) -> Vec<C
 where
     I: IntoIterator<Item = Q> + Clone,
 {
-    let mut point_query_map: BTreeMap<F, Vec<Q>> = BTreeMap::new();
+    let mut point_query_map: BTreeMap<Rotation, Vec<Q>> = BTreeMap::new();
     for query in queries.clone() {
-        if let Some(queries) = point_query_map.get_mut(&query.get_point()) {
+        if let Some(queries) = point_query_map.get_mut(&query.get_rotation()) {
             queries.push(query);
         } else {
-            point_query_map.insert(query.get_point(), vec![query]);
+            point_query_map.insert(query.get_rotation(), vec![query]);
         }
     }
 
     point_query_map
         .keys()
-        .map(|point| {
-            let queries = point_query_map.get(point).unwrap();
+        .map(|rot| {
+            let queries = point_query_map.get(rot).unwrap();
             CommitmentData {
                 queries: queries.clone(),
-                point: *point,
+                point: queries[0].get_point(),
                 _marker: PhantomData,
             }
         })

--- a/halo2_proofs/src/poly/multiopen/gwc/prover.rs
+++ b/halo2_proofs/src/poly/multiopen/gwc/prover.rs
@@ -1,6 +1,7 @@
 use super::{construct_intermediate_sets, ChallengeV, Query};
 use crate::arithmetic::{eval_polynomial, kate_division, CurveAffine, FieldExt};
 use crate::poly::multiopen::ProverQuery;
+use crate::poly::Rotation;
 use crate::poly::{commitment::Params, Coeff, Polynomial};
 use crate::transcript::{EncodedChallenge, TranscriptWrite};
 
@@ -67,6 +68,9 @@ impl<'a, C: CurveAffine> Query<C::Scalar> for ProverQuery<'a, C> {
 
     fn get_point(&self) -> C::Scalar {
         self.point
+    }
+    fn get_rotation(&self) -> Rotation {
+        self.rotation
     }
     fn get_eval(&self) -> C::Scalar {
         eval_polynomial(self.poly, self.get_point())

--- a/halo2_proofs/src/poly/multiopen/gwc/verifier.rs
+++ b/halo2_proofs/src/poly/multiopen/gwc/verifier.rs
@@ -1,5 +1,6 @@
 use super::{construct_intermediate_sets, ChallengeU, ChallengeV};
 use crate::arithmetic::{eval_polynomial, lagrange_interpolate, CurveAffine, FieldExt};
+use crate::poly::Rotation;
 use crate::poly::{
     commitment::{Params, ParamsVerifier},
     multiopen::{CommitmentReference, Query, VerifierQuery},
@@ -94,6 +95,9 @@ impl<'a, 'b, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
 
     fn get_point(&self) -> C::Scalar {
         self.point
+    }
+    fn get_rotation(&self) -> Rotation {
+        self.rotation
     }
     fn get_eval(&self) -> C::Scalar {
         self.eval

--- a/halo2_proofs/src/poly/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/multiopen/shplonk/prover.rs
@@ -6,7 +6,7 @@ use crate::arithmetic::{
     FieldExt,
 };
 use crate::poly::multiopen::ProverQuery;
-use crate::poly::{commitment::Params, Coeff, Error, Polynomial};
+use crate::poly::{commitment::Params, Coeff, Error, Polynomial, Rotation};
 use crate::transcript::{ChallengeScalar, EncodedChallenge, Transcript, TranscriptWrite};
 
 use ff::Field;
@@ -231,11 +231,14 @@ impl<'a, C: CurveAffine> PartialEq for PolynomialPointer<'a, C> {
 impl<'a, C: CurveAffine> Query<C::Scalar> for ProverQuery<'a, C> {
     type Commitment = PolynomialPointer<'a, C>;
 
+    fn get_rotation(&self) -> Rotation {
+        self.rotation
+    }
     fn get_point(&self) -> C::Scalar {
         self.point
     }
     fn get_eval(&self) -> C::Scalar {
-        eval_polynomial(self.poly, self.point)
+        eval_polynomial(self.poly, self.get_point())
     }
     fn get_commitment(&self) -> Self::Commitment {
         PolynomialPointer { poly: self.poly }

--- a/halo2_proofs/src/poly/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/multiopen/shplonk/verifier.rs
@@ -7,7 +7,7 @@ use crate::poly::{
     commitment::{Params, ParamsVerifier},
     msm::{PairMSM, PreMSM, ProjectiveMSM, MSM},
     multiopen::{CommitmentReference, Query, VerifierQuery},
-    {Coeff, Error, Polynomial},
+    Rotation, {Coeff, Error, Polynomial},
 };
 use crate::transcript::{EncodedChallenge, TranscriptRead};
 
@@ -92,6 +92,9 @@ where
 impl<'a, 'b, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
     type Commitment = CommitmentReference<'a, C>;
 
+    fn get_rotation(&self) -> Rotation {
+        self.rotation
+    }
     fn get_point(&self) -> C::Scalar {
         self.point
     }


### PR DESCRIPTION
In this PR we sort the opening points of a polynomial commitment according to their `Rotation` data. And this PR supports two PC schemes, i.e. 
- gwc
- shplonk
