### PR TITLE
dev: add name for lookup

### DIFF
--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -215,7 +215,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
          *   ...       ...    ...  0
          * ]
          */
-        meta.lookup(|meta| {
+        meta.lookup("lookup", |meta| {
             let a_ = meta.query_any(a, Rotation::cur());
             vec![(a_, sl)]
         });

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -154,6 +154,8 @@ pub enum VerifyFailure {
     },
     /// A lookup input did not exist in its corresponding table.
     Lookup {
+        /// The name of the lookup that is not satisfied.
+        name: &'static str,
         /// The index of the lookup that is not satisfied. These indices are assigned in
         /// the order in which `ConstraintSystem::lookup` is called during
         /// `Circuit::configure`.
@@ -215,9 +217,15 @@ impl fmt::Display for VerifyFailure {
                 )
             }
             Self::Lookup {
+                name,
                 lookup_index,
                 location,
-            } => write!(f, "Lookup {} is not satisfied {}", lookup_index, location),
+            } => {
+                write!(
+                    f,
+                    "Lookup {}(index: {}) is not satisfied {}",
+                    name, lookup_index, location
+                )
             Self::Permutation { column, row } => {
                 write!(
                     f,
@@ -938,6 +946,7 @@ impl<F: FieldExt> MockProver<F> {
                             None
                         } else {
                             Some(VerifyFailure::Lookup {
+                                name: lookup.name,
                                 lookup_index,
                                 location: FailureLocation::find_expressions(
                                     &self.cs,

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -226,6 +226,7 @@ impl fmt::Display for VerifyFailure {
                     "Lookup {}(index: {}) is not satisfied {}",
                     name, lookup_index, location
                 )
+            }
             Self::Permutation { column, row } => {
                 write!(
                     f,
@@ -1131,7 +1132,7 @@ mod tests {
                 let q = meta.complex_selector();
                 let table = meta.lookup_table_column();
 
-                meta.lookup(|cells| {
+                meta.lookup("lookup", |cells| {
                     let a = cells.query_advice(a, Rotation::cur());
                     let q = cells.query_selector(q);
 
@@ -1208,6 +1209,7 @@ mod tests {
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::Lookup {
+                name: "lookup",
                 lookup_index: 0,
                 location: FailureLocation::InRegion {
                     region: (2, "Faulty synthesis").into(),

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -917,6 +917,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// they need to match.
     pub fn lookup(
         &mut self,
+        name: &'static str,
         table_map: impl FnOnce(&mut VirtualCells<'_, F>) -> Vec<(Expression<F>, TableColumn)>,
     ) -> usize {
         let mut cells = VirtualCells::new(self);
@@ -935,7 +936,7 @@ impl<F: Field> ConstraintSystem<F> {
 
         let index = self.lookups.len();
 
-        self.lookups.push(lookup::Argument::new(table_map));
+        self.lookups.push(lookup::Argument::new(name, table_map));
 
         index
     }
@@ -948,6 +949,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// This API allows any column type to be used as table columns.
     pub fn lookup_any(
         &mut self,
+        name: &'static str,
         table_map: impl FnOnce(&mut VirtualCells<'_, F>) -> Vec<(Expression<F>, Expression<F>)>,
     ) -> usize {
         let mut cells = VirtualCells::new(self);
@@ -955,7 +957,7 @@ impl<F: Field> ConstraintSystem<F> {
 
         let index = self.lookups.len();
 
-        self.lookups.push(lookup::Argument::new(table_map));
+        self.lookups.push(lookup::Argument::new(name, table_map));
 
         index
     }

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -6,6 +6,7 @@ pub(crate) mod verifier;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Argument<F: Field> {
+    pub name: &'static str,
     pub input_expressions: Vec<Expression<F>>,
     pub table_expressions: Vec<Expression<F>>,
 }
@@ -14,9 +15,10 @@ impl<F: Field> Argument<F> {
     /// Constructs a new lookup argument.
     ///
     /// `table_map` is a sequence of `(input, table)` tuples.
-    pub fn new(table_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
+    pub fn new(name: &'static str, table_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
         let (input_expressions, table_expressions) = table_map.into_iter().unzip();
         Argument {
+            name,
             input_expressions,
             table_expressions,
         }

--- a/halo2_proofs/tests/lookup_any.rs
+++ b/halo2_proofs/tests/lookup_any.rs
@@ -208,7 +208,4 @@ fn lookup_any() {
     // the odd number lookup will fail.
     let prover = MockProver::run(k, &circuit, vec![even_lookup]).unwrap();
     assert!(prover.verify().is_err())
-                name: "odd number",
-                name: "odd number",
-                name: "odd number",
 }

--- a/halo2_proofs/tests/lookup_any.rs
+++ b/halo2_proofs/tests/lookup_any.rs
@@ -1,3 +1,4 @@
+
 use std::marker::PhantomData;
 
 use halo2_proofs::{
@@ -37,7 +38,7 @@ fn lookup_any() {
             };
 
             // Lookup on even numbers
-            meta.lookup_any(|meta| {
+            meta.lookup_any("even number", |meta| {
                 let input = meta.query_advice(config.input, Rotation::cur());
 
                 let q_even = meta.query_selector(config.q_even);
@@ -47,7 +48,7 @@ fn lookup_any() {
             });
 
             // Lookup on odd numbers
-            meta.lookup_any(|meta| {
+            meta.lookup_any("odd number", |meta| {
                 let input = meta.query_advice(config.input, Rotation::cur());
 
                 let q_odd = meta.query_selector(config.q_odd);
@@ -207,4 +208,7 @@ fn lookup_any() {
     // the odd number lookup will fail.
     let prover = MockProver::run(k, &circuit, vec![even_lookup]).unwrap();
     assert!(prover.verify().is_err())
+                name: "odd number",
+                name: "odd number",
+                name: "odd number",
 }

--- a/halo2_proofs/tests/lookup_any.rs
+++ b/halo2_proofs/tests/lookup_any.rs
@@ -1,4 +1,3 @@
-
 use std::marker::PhantomData;
 
 use halo2_proofs::{

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -299,7 +299,7 @@ fn plonk_api() {
              * ]
              */
 
-            meta.lookup(|meta| {
+            meta.lookup("lookup", |meta| {
                 let a_ = meta.query_any(a, Rotation::cur());
                 vec![(a_, sl)]
             });


### PR DESCRIPTION
Currently the lookup error message only contains the lookup index but no lookup name. So debugging lookup error is very difficult. This PR add a name to lookup, so VerifyFailure::Lookup can contain the lookup name.

Solves https://github.com/appliedzkp/halo2/issues/17 and https://github.com/zcash/halo2/issues/441