### PR TITLE
Make `construct_intermediate_sets` to have static ordering opening points

### DIFF
--- a/halo2_proofs/src/poly/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/multiopen/shplonk.rs
@@ -292,3 +292,116 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    use proptest::{
+        collection::vec,
+        prelude::*,
+        sample::{select, subsequence},
+        strategy::Strategy,
+    };
+
+    use super::{construct_intermediate_sets, IntermediateSets};
+    use crate::poly::Rotation;
+    use pairing::{
+        arithmetic::BaseExt,
+        bn256::{Bn256, Fr as Fp, G1Affine},
+    };
+
+    use std::collections::BTreeMap;
+    use std::convert::TryFrom;
+
+    #[derive(Debug, Clone)]
+    struct MyQuery<F> {
+        point: F,
+        eval: F,
+        commitment: usize,
+    }
+
+    impl super::Query<Fp> for MyQuery<Fp> {
+        type Commitment = usize;
+
+        fn get_point(&self) -> Fp {
+            self.point
+        }
+
+        fn get_eval(&self) -> Fp {
+            self.eval
+        }
+
+        fn get_commitment(&self) -> Self::Commitment {
+            self.commitment
+        }
+    }
+
+    prop_compose! {
+        fn arb_point()(
+            bytes in vec(any::<u8>(), 64)
+        ) -> Fp {
+            Fp::from_bytes_wide(&<[u8; 64]>::try_from(bytes).unwrap())
+        }
+    }
+
+    prop_compose! {
+        fn arb_query(commitment: usize, point: Fp)(
+            eval in arb_point()
+        ) -> MyQuery<Fp> {
+            MyQuery {
+                point,
+                eval,
+                commitment
+            }
+        }
+    }
+
+    prop_compose! {
+        // Mapping from column index to point index.
+        fn arb_queries_inner(num_points: usize, num_cols: usize, num_queries: usize)(
+            col_indices in vec(select((0..num_cols).collect::<Vec<_>>()), num_queries),
+            point_indices in vec(select((0..num_points).collect::<Vec<_>>()), num_queries)
+        ) -> Vec<(usize, usize)> {
+            col_indices.into_iter().zip(point_indices.into_iter()).collect()
+        }
+    }
+
+    prop_compose! {
+        fn compare_queries(
+            num_points: usize,
+            num_cols: usize,
+            num_queries: usize,
+        )(
+            points_1 in vec(arb_point(), num_points),
+            points_2 in vec(arb_point(), num_points),
+            mapping in arb_queries_inner(num_points, num_cols, num_queries)
+        )(
+            queries_1 in mapping.iter().map(|(commitment, point_idx)| arb_query(*commitment, points_1[*point_idx])).collect::<Vec<_>>(),
+            queries_2 in mapping.iter().map(|(commitment, point_idx)| arb_query(*commitment, points_2[*point_idx])).collect::<Vec<_>>(),
+        ) -> (
+            Vec<MyQuery<Fp>>,
+            Vec<MyQuery<Fp>>
+        ) {
+            (
+                queries_1,
+                queries_2,
+            )
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_intermediate_sets(
+            (queries_1, queries_2) in compare_queries(8, 8, 16)
+        ) {
+            let IntermediateSets { rotation_sets, .. } = construct_intermediate_sets(queries_1);
+            let all_point_indices = rotation_sets.iter().map(|data| data.point_indices.clone()).collect::<Vec<_>>();
+
+            // It shouldn't matter what the point or eval values are; we should get
+            // the same exact point indices again.
+            let IntermediateSets { rotation_sets: new_rotation_sets, .. } = construct_intermediate_sets(queries_2);
+            let new_all_point_indices = new_rotation_sets.iter().map(|data| data.point_indices.clone()).collect::<Vec<_>>();
+
+            assert_eq!(all_point_indices, new_all_point_indices);
+        }
+    }
+}

--- a/halo2_proofs/src/poly/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/multiopen/shplonk.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
     marker::PhantomData,
 };
 
@@ -41,10 +41,28 @@ impl<F: FieldExt, T: PartialEq + Clone> Commitment<F, T> {
     }
 }
 
+#[derive(Clone)]
 struct RotationSet<F: FieldExt, T: PartialEq + Clone> {
     commitments: Vec<Commitment<F, T>>,
-    points: Vec<F>,
-    diffs: Vec<F>,
+    point_indices: Vec<usize>,
+}
+
+impl<F: FieldExt, T: PartialEq + Clone> RotationSet<F, T> {
+    fn points(&self, super_point_set: &[F]) -> Vec<F> {
+        self.point_indices
+            .iter()
+            .map(|idx| super_point_set[*idx])
+            .collect()
+    }
+
+    fn diffs(&self, super_point_set: &[F]) -> Vec<F> {
+        super_point_set
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !self.point_indices.contains(idx))
+            .map(|(_, point)| *point)
+            .collect()
+    }
 }
 
 struct IntermediateSets<F: FieldExt, Q: Query<F>> {
@@ -56,160 +74,108 @@ fn construct_intermediate_sets<F: FieldExt, I, Q: Query<F>>(queries: I) -> Inter
 where
     I: IntoIterator<Item = Q> + Clone,
 {
-    // 1. collect points to construct vanishing polynomial of all points
-    let mut super_point_set = BTreeSet::new();
-    // point_set = { p_0, p_1, ... }
+    // Construct sets of unique commitments and corresponding queried points.
+    let mut commitment_map: Vec<(Q::Commitment, Vec<usize>)> = vec![];
+
+    // Also construct mapping from a unique point to a point_index. This defines
+    // an ordering on the points.
+    let mut point_index_map = BTreeMap::new();
+
+    // Collect all different points as a super set.
+    let mut super_point_set = vec![];
+
+    // Iterate over all of the queries, computing the ordering of the points
+    // while also creating new commitment data.
     for query in queries.clone() {
-        super_point_set.insert(query.get_point());
-    }
-
-    // 2. identify commitments
-    // commitment_ids = [(1, c_0), (2, c_1), ... ]
-    let mut commitment_ids = vec![];
-    // id index starts from 1
-    let mut id = 1usize;
-    for query in queries.clone() {
-        let mut found = false;
-        for (_, commitment) in commitment_ids.iter() {
-            if *commitment == query.get_commitment() {
-                found = true;
-                break;
+        let num_points = point_index_map.len();
+        let point_index = match point_index_map.entry(query.get_point()) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                super_point_set.push(*entry.key());
+                *entry.insert(num_points)
             }
-        }
-        if !found {
-            commitment_ids.push((id, query.get_commitment()));
-            id += 1;
-        }
-    }
-
-    let get_commitment = |id: usize| -> Q::Commitment {
-        for (_id, commitment) in commitment_ids.clone().into_iter() {
-            if _id == id {
-                return commitment;
-            }
-        }
-        panic!("must find a commitment");
-    };
-
-    let get_commitment_id = |query: &Q| -> usize {
-        let mut id = 0;
-        for (_id, commitment) in commitment_ids.iter() {
-            if query.get_commitment() == *commitment {
-                id = *_id;
-            } else {
-                continue;
-            }
-        }
-        // an id must be found
-        assert_ne!(id, 0);
-
-        id
-    };
-
-    // 3.a. map points to commitments
-    // commitment_id_point_map = { c_1: { p_0, p_1, ... }, c_2: { p_1, p_2, ... }, ... }
-    let mut commitment_id_point_map = BTreeMap::new();
-    // 3.b. map points to commitments
-    // commitment_id_point_eval_map_map = { c_1: { p_0: e_0, p_1: e_1, ... }, c_2: { p_1: e_1, p_2: e_2, ... }, ... }
-    let mut commitment_id_point_eval_map_map = BTreeMap::new();
-    for query in queries.clone() {
-        let id = get_commitment_id(&query);
-
-        commitment_id_point_map
-            .entry(id)
-            // create new set for points
-            .or_insert_with(BTreeSet::new)
-            // insert the point, there won't be duplicates
-            .insert(query.get_point());
-
-        commitment_id_point_eval_map_map
-            .entry(id)
-            // create new map for point to eval map
-            .or_insert_with(BTreeMap::new)
-            // insert point eval key values
-            .insert(query.get_point(), query.get_eval());
-    }
-
-    // 4. find diff points
-    // commitment_id_diff_points_map = { c_1:  { p_2, p_3, ... }, c_2: { p_0 }, ... }
-    let mut commitment_id_diff_points_map = BTreeMap::new();
-    for query in queries {
-        let id = get_commitment_id(&query);
-        let commitment_point_set = commitment_id_point_map.get(&id).unwrap();
-
-        // diff_set = super_point_set \ commitment_point_set
-        let diff_set: BTreeSet<F> = super_point_set
-            .difference(commitment_point_set)
-            .cloned()
-            .collect();
-        commitment_id_diff_points_map.insert(id, diff_set);
-    }
-
-    assert_eq!(
-        commitment_id_point_map.len(),
-        commitment_id_diff_points_map.len()
-    );
-
-    // 5. construct point_set to commitment map
-    // counterwise of commitment_id_diff_points_map
-    let mut points_commitment_id_map = BTreeMap::new();
-    for (commitment_id, point_set) in commitment_id_point_map.iter() {
-        points_commitment_id_map
-            .entry(point_set)
-            // create new set for commitment ids
-            .or_insert_with(BTreeSet::new)
-            // insert the id, there won't be duplicates
-            .insert(*commitment_id);
-    }
-
-    // 6. finally construct intermediate sets
-    let mut rotation_sets = vec![];
-    for (points, commitment_ids) in points_commitment_id_map {
-        assert!(!commitment_ids.is_empty());
-        let commitment_ids: Vec<usize> = commitment_ids.iter().cloned().collect();
-
-        let commitments: Vec<Commitment<F, Q::Commitment>> = commitment_ids
-            .iter()
-            .map(|id| {
-                let commitment = get_commitment(*id);
-
-                let point_eval_map = commitment_id_point_eval_map_map.get(id).unwrap();
-                let evals: Vec<F> = points
-                    .iter()
-                    .map(|point| *point_eval_map.get(point).unwrap())
-                    .collect();
-                Commitment((commitment, evals))
-            })
-            .collect();
-
-        let some_id = commitment_ids[0];
-        let diffs: Vec<F> = commitment_id_diff_points_map
-            .get(&some_id)
-            .unwrap()
-            .iter()
-            .cloned()
-            .collect();
-        let points: Vec<F> = points.iter().cloned().collect();
-
-        let rotation_set = RotationSet {
-            commitments,
-            points,
-            diffs,
         };
 
-        rotation_sets.push(rotation_set);
+        if let Some(pos) = commitment_map
+            .iter()
+            .position(|(commitment, _)| *commitment == query.get_commitment())
+        {
+            let (_, point_indices) = &mut commitment_map[pos];
+            if !point_indices.iter().any(|idx| *idx == point_index) {
+                point_indices.push(point_index);
+            }
+        } else {
+            commitment_map.push((query.get_commitment(), vec![point_index]));
+        };
+    }
+
+    // Construct rotation set
+    let mut rotation_sets = vec![];
+    // Also construct mapping from commitment to index of rotation_sets
+    let commitment_set_idx_map = {
+        // Construct map of unique ordered point_indices_sets to their set_index
+        let mut point_indices_sets = BTreeMap::new();
+
+        commitment_map
+            .into_iter()
+            .map(|(commitment, point_indices)| {
+                let num_points = point_indices.len();
+                let point_index_set = point_indices.iter().cloned().collect::<BTreeSet<_>>();
+                debug_assert!(num_points == point_index_set.len());
+
+                let num_sets = point_indices_sets.len();
+                let set_index = match point_indices_sets.entry(point_index_set) {
+                    Entry::Vacant(entry) => {
+                        rotation_sets.push(RotationSet {
+                            commitments: vec![],
+                            point_indices,
+                        });
+                        *entry.insert(num_sets)
+                    }
+                    Entry::Occupied(entry) => *entry.get(),
+                };
+
+                let commitment_index = rotation_sets[set_index].commitments.len();
+                rotation_sets[set_index].commitments.push(Commitment((
+                    commitment.clone(),
+                    vec![F::zero(); num_points],
+                )));
+
+                (commitment, set_index, commitment_index)
+            })
+            .collect::<Vec<_>>()
+    };
+
+    // Populate evals for each commitment in each rotation_set
+    for query in queries {
+        // The index of the point at which the commitment is queried
+        let point_index = point_index_map.get(&query.get_point()).unwrap();
+
+        let (_, set_index, commitment_index) = commitment_set_idx_map
+            .iter()
+            .find(|(commitment, _, _)| query.get_commitment() == *commitment)
+            .unwrap();
+
+        let rotation_set = &mut rotation_sets[*set_index];
+        let Commitment((_, evals)) = &mut rotation_set.commitments[*commitment_index];
+
+        let point_index_in_set = rotation_set
+            .point_indices
+            .iter()
+            .position(|i| i == point_index)
+            .unwrap();
+        evals[point_index_in_set] = query.get_eval();
     }
 
     IntermediateSets {
         rotation_sets,
-        super_point_set: super_point_set.iter().cloned().collect(),
+        super_point_set,
     }
 }
 
 #[cfg(test)]
 mod tests {
-
-    use super::construct_intermediate_sets;
+    use super::{construct_intermediate_sets, IntermediateSets};
     use crate::arithmetic::{eval_polynomial, FieldExt};
     use crate::pairing::bn256::{Bn256, Fr, G1Affine};
     use crate::poly::{
@@ -300,10 +266,10 @@ mod tests {
         assert_eq!(intermediate_sets.rotation_sets.len(), rotation_sets.len());
         assert_eq!(intermediate_sets.super_point_set, super_point_set);
 
-        let (rotation_sets, super_point_set) = (
-            intermediate_sets.rotation_sets,
-            intermediate_sets.super_point_set,
-        );
+        let IntermediateSets {
+            rotation_sets,
+            super_point_set,
+        } = intermediate_sets;
 
         for (i, rotation_set) in rotation_sets.iter().enumerate() {
             let commitments = rotation_set.commitments.clone();
@@ -313,8 +279,8 @@ mod tests {
                 assert_eq!(commitment_id, number_of_sets * j + i);
             }
 
-            let points: Vec<Fr> = rotation_set.points.clone();
-            let diffs: Vec<Fr> = rotation_set.diffs.clone();
+            let points: Vec<Fr> = rotation_set.points(&super_point_set);
+            let diffs: Vec<Fr> = rotation_set.diffs(&super_point_set);
 
             assert_eq!(points.len(), rotation_sets_init[i].len());
 


### PR DESCRIPTION
Currently the function `construct_intermediate_sets` of `shplonk` and `gwc` is implemented to output non-static ordered of opening points, which is due to iterating on `BTreeMap`.

Since aggregation circuit needs static ordering of opening points, PR #27 then solves this issue by introducing field `rotation` for `ProverQuery` as a ordering key, which is then static.

However, I think it's better to change the common structures as less as possible, to make our future rebasing works easier. So this PR tries to follow the logic of [`construct_intermediate_sets` upstream halo2](https://github.com/zcash/halo2/blob/main/halo2_proofs/src/poly/multiopen.rs#L138), to always iterate on `queries` to collect to be `IntermediateSet`, which is then static ordered. I also copy the [`proptests` from upstream halo2](https://github.com/zcash/halo2/blob/main/halo2_proofs/src/poly/multiopen.rs#L391-L503) for testing static ordering (in the second commit).

