### PR TITLE
Domain Evaluation Optimization

### DIFF
--- a/halo2/src/lib.rs
+++ b/halo2/src/lib.rs
@@ -1,7 +1,7 @@
 //! # halo2
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]

--- a/halo2_gadgets/src/lib.rs
+++ b/halo2_gadgets/src/lib.rs
@@ -4,7 +4,7 @@
 // Temporary until we have more of the crate implemented.
 #![allow(dead_code)]
 // Catch documentation errors caused by code changes.
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -252,7 +252,7 @@ pub fn best_fft<F: FieldExt>(input: &mut [F], fft_data: &FFTData<F>, is_inv: boo
     }
 }
 
-fn low_degree_butterly_arithmetic<F: FieldExt>(input: &mut [F], twiddles: &Vec<F>) {
+fn low_degree_butterly_arithmetic<F: FieldExt>(input: &mut [F], twiddles: &[F]) {
     let n = input.len();
     let stash = input.to_vec();
     let indexes = match n {
@@ -331,7 +331,7 @@ fn low_degree_butterly_arithmetic<F: FieldExt>(input: &mut [F], twiddles: &Vec<F
 fn bottom_layers_butterfly_arithmetic<F: FieldExt>(
     input: &mut [F],
     fft_data: &FFTData<F>,
-    twiddles: &Vec<F>,
+    twiddles: &[F],
 ) {
     let stash = input.to_vec();
     // twiddles factor 16th root of unity

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -3,7 +3,7 @@
 //!
 //! [halo]: https://eprint.iacr.org/2019/1021
 
-use super::{Coeff, LagrangeCoeff, Polynomial, MSM};
+use super::{Coeff, FFTData, LagrangeCoeff, Polynomial, MSM};
 use crate::arithmetic::{
     best_fft, best_multiexp, parallelize, CurveAffine, CurveExt, Engine, FieldExt, Group,
 };
@@ -12,10 +12,10 @@ use crate::helpers::CurveRead;
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
 use rand_core::OsRng;
+use rayon::{current_num_threads, scope};
+use std::io;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Mul, MulAssign};
-
-use std::io;
 
 /// These are the prover parameters for the polynomial commitment scheme.
 #[derive(Debug)]
@@ -84,7 +84,7 @@ impl<C: CurveAffine> Params<C> {
             alpha_inv = alpha_inv.square();
         }
         let mut g_lagrange_projective = g_projective;
-        best_fft(&mut g_lagrange_projective, alpha_inv, k);
+        prev_fft(&mut g_lagrange_projective, alpha_inv, k);
         let minv = E::Scalar::TWO_INV.pow_vartime(&[k as u64, 0, 0, 0]);
         parallelize(&mut g_lagrange_projective, |g, _| {
             for g in g.iter_mut() {
@@ -334,6 +334,116 @@ impl<E: Engine> ParamsVerifier<E> {
             g_lagrange,
         })
     }
+}
+
+/// This will use multithreading if beneficial.
+pub fn prev_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32) {
+    let threads = current_num_threads();
+    let log_threads = log2_floor(threads);
+
+    if log_n <= log_threads {
+        serial_fft(a, omega, log_n);
+    } else {
+        parallel_fft(a, omega, log_n, log_threads);
+    }
+}
+
+fn serial_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32) {
+    fn bitreverse(mut n: u32, l: u32) -> u32 {
+        let mut r = 0;
+        for _ in 0..l {
+            r = (r << 1) | (n & 1);
+            n >>= 1;
+        }
+        r
+    }
+
+    let n = a.len() as u32;
+    assert_eq!(n, 1 << log_n);
+
+    for k in 0..n {
+        let rk = bitreverse(k, log_n);
+        if k < rk {
+            a.swap(rk as usize, k as usize);
+        }
+    }
+
+    let mut m = 1;
+    for _ in 0..log_n {
+        let w_m = omega.pow_vartime(&[u64::from(n / (2 * m)), 0, 0, 0]);
+
+        let mut k = 0;
+        while k < n {
+            let mut w = G::Scalar::one();
+            for j in 0..m {
+                let mut t = a[(k + j + m) as usize];
+                t.group_scale(&w);
+                a[(k + j + m) as usize] = a[(k + j) as usize];
+                a[(k + j + m) as usize].group_sub(&t);
+                a[(k + j) as usize].group_add(&t);
+                w *= &w_m;
+            }
+
+            k += 2 * m;
+        }
+
+        m *= 2;
+    }
+}
+
+fn parallel_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32, log_threads: u32) {
+    assert!(log_n >= log_threads);
+
+    let num_threads = 1 << log_threads;
+    let log_new_n = log_n - log_threads;
+    let mut tmp = vec![vec![G::group_zero(); 1 << log_new_n]; num_threads];
+    let new_omega = omega.pow_vartime(&[num_threads as u64, 0, 0, 0]);
+
+    scope(|scope| {
+        let a = &*a;
+
+        for (j, tmp) in tmp.iter_mut().enumerate() {
+            scope.spawn(move |_| {
+                // Shuffle into a sub-FFT
+                let omega_j = omega.pow_vartime(&[j as u64, 0, 0, 0]);
+                let omega_step = omega.pow_vartime(&[(j as u64) << log_new_n, 0, 0, 0]);
+
+                let mut elt = G::Scalar::one();
+
+                for (i, tmp) in tmp.iter_mut().enumerate() {
+                    for s in 0..num_threads {
+                        let idx = (i + (s << log_new_n)) % (1 << log_n);
+                        let mut t = a[idx];
+                        t.group_scale(&elt);
+                        tmp.group_add(&t);
+                        elt *= &omega_step;
+                    }
+                    elt *= &omega_j;
+                }
+
+                // Perform sub-FFT
+                serial_fft(tmp, new_omega, log_new_n);
+            });
+        }
+    });
+
+    // Unshuffle
+    let mask = (1 << log_threads) - 1;
+    for (idx, a) in a.iter_mut().enumerate() {
+        *a = tmp[idx & mask][idx >> log_threads];
+    }
+}
+
+fn log2_floor(num: usize) -> u32 {
+    assert!(num > 0);
+
+    let mut pow = 0;
+
+    while (1 << (pow + 1)) <= num {
+        pow += 1;
+    }
+
+    pow
 }
 
 #[cfg(test)]

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     arithmetic::{best_fft, parallelize, FieldExt, Group},
+    multicore,
     plonk::Assigned,
 };
 
@@ -10,39 +11,62 @@ use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
 use group::ff::{BatchInvert, Field, PrimeField};
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, os::unix::prelude::FileExt};
 
-/// This structure holds the twiddles, bit reversed index and radix for each layer
+/// This structure hold the twiddles and radix for each layer
 #[derive(Debug)]
 pub struct FFTData<F: FieldExt> {
     /// n half
     pub half: usize,
     /// stages
-    pub stages: Vec<usize>,
+    pub layer: usize,
     /// indexes for bit reverse
     pub indexes: Vec<usize>,
     /// twiddles
-    pub f_twiddles: Vec<F>,
+    pub twiddles: Vec<F>,
+    /// inv twiddles
+    pub inv_twiddles: Vec<F>,
+    /// odd k flag
+    pub is_odd: bool,
+    /// low degree flag
+    pub is_low: bool,
 }
 
 impl<F: FieldExt> FFTData<F> {
     /// Create twiddles and stages data
-    pub fn new(n: usize, omega: F, k: usize) -> Self {
-        let mut w = F::one();
+    pub fn new(n: usize, omega: F, omega_inv: F, k: usize) -> Self {
         let half = n / 2;
-        let mut f_twiddles = Vec::with_capacity(half);
-        let offset = k - 4;
-        let mut stages = Vec::with_capacity(offset / 2 + offset % 2);
+        let (offset, is_low) = if k < 4 { (0, true) } else { (k - 4, false) };
         let mut counter = 2;
-        let mut indexes = vec![0; n];
 
         // calculate twiddles factor
-        for _ in 0..half {
-            f_twiddles.push(w);
-            w *= omega;
-        }
+        let mut w = F::one();
+        let mut i = F::one();
+        let mut twiddles = vec![F::one(); half];
+        let mut inv_twiddles = vec![F::one(); half];
 
         // init bit reverse indexes
+        let mut indexes = vec![0; n];
+
+        // mutable reference for multicore
+        let stash = &mut twiddles;
+        let i_stash = &mut inv_twiddles;
+
+        multicore::scope(|scope| {
+            scope.spawn(move |_| {
+                for tw in stash.iter_mut() {
+                    *tw = w;
+                    w *= omega;
+                }
+            });
+            scope.spawn(move |_| {
+                for tw in i_stash.iter_mut() {
+                    *tw = i;
+                    i *= omega_inv;
+                }
+            });
+        });
+
         if k % 2 != 0 {
             indexes[0] = 0;
             indexes[1] = 1;
@@ -54,7 +78,7 @@ impl<F: FieldExt> FFTData<F> {
             counter *= 2;
         }
 
-        // calculate 1 / 4 size bit reverse indexes
+        // calculate bit reverse indexes
         while counter != n {
             for i in 0..counter {
                 indexes[i] *= 4;
@@ -65,19 +89,48 @@ impl<F: FieldExt> FFTData<F> {
             counter *= 4;
         }
 
-        // stages and radix
-        for _ in 0..offset / 2 {
-            stages.push(4);
-        }
-        if k % 2 == 1 {
-            stages.push(2)
-        }
-
         Self {
             half,
-            stages,
-            f_twiddles,
+            layer: offset / 2,
             indexes,
+            twiddles,
+            inv_twiddles,
+            is_odd: k % 2 == 1,
+            is_low,
+        }
+    }
+}
+
+/// This structure hold the twiddles and radix for each layer
+#[derive(Debug)]
+pub struct EvaluationHelper<F: FieldExt> {
+    /// fft data
+    pub fft_data: FFTData<F>,
+    /// extended fft data
+    pub ext_fft_data: FFTData<F>,
+}
+
+impl<F: FieldExt> EvaluationHelper<F> {
+    /// Create twiddles and stages data
+    pub fn new(
+        n: usize,
+        extended_n: usize,
+        omega: F,
+        omega_inv: F,
+        extended_omega: F,
+        extended_omega_inv: F,
+        k: usize,
+        extended_k: usize,
+    ) -> Self {
+        assert_eq!(n, 1 << k);
+        assert_eq!(extended_n, 1 << extended_k);
+
+        let fft_data = FFTData::new(n, omega, omega_inv, k);
+        let ext_fft_data = FFTData::new(extended_n, extended_omega, extended_omega_inv, extended_k);
+
+        Self {
+            fft_data,
+            ext_fft_data,
         }
     }
 }
@@ -86,25 +139,24 @@ impl<F: FieldExt> FFTData<F> {
 /// performing operations on an evaluation domain of size $2^k$ and an extended
 /// domain of size $2^{k} * j$ with $j \neq 0$.
 #[derive(Debug)]
-pub struct EvaluationDomain<G: Group> {
+pub struct EvaluationDomain<F: FieldExt> {
     n: u64,
     k: u32,
     extended_k: u32,
-    omega: G::Scalar,
-    omega_inv: G::Scalar,
-    extended_omega: G::Scalar,
-    extended_omega_inv: G::Scalar,
-    g_coset: G::Scalar,
-    g_coset_inv: G::Scalar,
+    omega: F,
+    omega_inv: F,
+    extended_omega: F,
+    g_coset: F,
+    g_coset_inv: F,
     quotient_poly_degree: u64,
-    ifft_divisor: G::Scalar,
-    extended_ifft_divisor: G::Scalar,
-    t_evaluations: Vec<G::Scalar>,
-    barycentric_weight: G::Scalar,
-    fft_data: FFTData<G::Scalar>,
+    ifft_divisor: F,
+    extended_ifft_divisor: F,
+    t_evaluations: Vec<F>,
+    barycentric_weight: F,
+    evaluation_helper: EvaluationHelper<F>,
 }
 
-impl<G: Group> EvaluationDomain<G> {
+impl<F: FieldExt> EvaluationDomain<F> {
     /// This constructs a new evaluation domain object based on the provided
     /// values $j, k$.
     pub fn new(j: u32, k: u32) -> Self {
@@ -122,12 +174,12 @@ impl<G: Group> EvaluationDomain<G> {
             extended_k += 1;
         }
 
-        let mut extended_omega = G::Scalar::root_of_unity();
+        let mut extended_omega = F::Scalar::root_of_unity();
 
         // Get extended_omega, the 2^{extended_k}'th root of unity
         // The loop computes extended_omega = omega^{2 ^ (S - extended_k)}
         // Notice that extended_omega ^ {2 ^ extended_k} = omega ^ {2^S} = 1.
-        for _ in extended_k..G::Scalar::S {
+        for _ in extended_k..F::Scalar::S {
             extended_omega = extended_omega.square();
         }
         let extended_omega = extended_omega;
@@ -149,14 +201,14 @@ impl<G: Group> EvaluationDomain<G> {
         // already.
         // The coset evaluation domain is:
         // zeta {1, extended_omega, extended_omega^2, ..., extended_omega^{(2^extended_k) - 1}}
-        let g_coset = G::Scalar::ZETA;
+        let g_coset = F::Scalar::ZETA;
         let g_coset_inv = g_coset.square();
 
         let mut t_evaluations = Vec::with_capacity(1 << (extended_k - k));
         {
             // Compute the evaluations of t(X) = X^n - 1 in the coset evaluation domain.
             // We don't have to compute all of them, because it will repeat.
-            let orig = G::Scalar::ZETA.pow_vartime(&[n as u64, 0, 0, 0]);
+            let orig = F::Scalar::ZETA.pow_vartime(&[n as u64, 0, 0, 0]);
             let step = extended_omega.pow_vartime(&[n as u64, 0, 0, 0]);
             let mut cur = orig;
             loop {
@@ -170,19 +222,19 @@ impl<G: Group> EvaluationDomain<G> {
 
             // Subtract 1 from each to give us t_evaluations[i] = t(zeta * extended_omega^i)
             for coeff in &mut t_evaluations {
-                *coeff -= &G::Scalar::one();
+                *coeff -= &F::Scalar::one();
             }
 
             // Invert, because we're dividing by this polynomial.
             // We invert in a batch, below.
         }
 
-        let mut ifft_divisor = G::Scalar::from(1 << k); // Inversion computed later
-        let mut extended_ifft_divisor = G::Scalar::from(1 << extended_k); // Inversion computed later
+        let mut ifft_divisor = F::Scalar::from(1 << k); // Inversion computed later
+        let mut extended_ifft_divisor = F::Scalar::from(1 << extended_k); // Inversion computed later
 
         // The barycentric weight of 1 over the evaluation domain
         // 1 / \prod_{i != 0} (1 - omega^i)
-        let mut barycentric_weight = G::Scalar::from(n); // Inversion computed later
+        let mut barycentric_weight = F::Scalar::from(n); // Inversion computed later
 
         // Compute batch inversion
         t_evaluations
@@ -201,7 +253,6 @@ impl<G: Group> EvaluationDomain<G> {
             omega,
             omega_inv,
             extended_omega,
-            extended_omega_inv,
             g_coset,
             g_coset_inv,
             quotient_poly_degree,
@@ -209,14 +260,23 @@ impl<G: Group> EvaluationDomain<G> {
             extended_ifft_divisor,
             t_evaluations,
             barycentric_weight,
-            fft_data: FFTData::<G::Scalar>::new(n as usize, omega, k as usize),
+            evaluation_helper: EvaluationHelper::<F::Scalar>::new(
+                n as usize,
+                (1 << extended_k) as usize,
+                omega,
+                omega_inv,
+                extended_omega,
+                extended_omega_inv,
+                k as usize,
+                extended_k as usize,
+            ),
         }
     }
 
     /// Obtains a polynomial in Lagrange form when given a vector of Lagrange
     /// coefficients of size `n`; panics if the provided vector is the wrong
     /// length.
-    pub fn lagrange_from_vec(&self, values: Vec<G>) -> Polynomial<G, LagrangeCoeff> {
+    pub fn lagrange_from_vec(&self, values: Vec<F>) -> Polynomial<F, LagrangeCoeff> {
         assert_eq!(values.len(), self.n as usize);
 
         Polynomial {
@@ -228,7 +288,7 @@ impl<G: Group> EvaluationDomain<G> {
     /// Obtains a polynomial in coefficient form when given a vector of
     /// coefficients of size `n`; panics if the provided vector is the wrong
     /// length.
-    pub fn coeff_from_vec(&self, values: Vec<G>) -> Polynomial<G, Coeff> {
+    pub fn coeff_from_vec(&self, values: Vec<F>) -> Polynomial<F, Coeff> {
         assert_eq!(values.len(), self.n as usize);
 
         Polynomial {
@@ -238,35 +298,35 @@ impl<G: Group> EvaluationDomain<G> {
     }
 
     /// Returns an empty (zero) polynomial in the coefficient basis
-    pub fn empty_coeff(&self) -> Polynomial<G, Coeff> {
+    pub fn empty_coeff(&self) -> Polynomial<F, Coeff> {
         Polynomial {
-            values: vec![G::group_zero(); self.n as usize],
+            values: vec![F::group_zero(); self.n as usize],
             _marker: PhantomData,
         }
     }
 
     /// Returns an empty (zero) polynomial in the Lagrange coefficient basis
-    pub fn empty_lagrange(&self) -> Polynomial<G, LagrangeCoeff> {
+    pub fn empty_lagrange(&self) -> Polynomial<F, LagrangeCoeff> {
         Polynomial {
-            values: vec![G::group_zero(); self.n as usize],
+            values: vec![F::group_zero(); self.n as usize],
             _marker: PhantomData,
         }
     }
 
     /// Returns an empty (zero) polynomial in the Lagrange coefficient basis, with
     /// deferred inversions.
-    pub(crate) fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<G>, LagrangeCoeff>
+    pub(crate) fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<F>, LagrangeCoeff>
     where
-        G: Field,
+        F: Field,
     {
         Polynomial {
-            values: vec![G::group_zero().into(); self.n as usize],
+            values: vec![F::group_zero().into(); self.n as usize],
             _marker: PhantomData,
         }
     }
 
     /// Returns a constant polynomial in the Lagrange coefficient basis
-    pub fn constant_lagrange(&self, scalar: G) -> Polynomial<G, LagrangeCoeff> {
+    pub fn constant_lagrange(&self, scalar: F) -> Polynomial<F, LagrangeCoeff> {
         Polynomial {
             values: vec![scalar; self.n as usize],
             _marker: PhantomData,
@@ -275,16 +335,16 @@ impl<G: Group> EvaluationDomain<G> {
 
     /// Returns an empty (zero) polynomial in the extended Lagrange coefficient
     /// basis
-    pub fn empty_extended(&self) -> Polynomial<G, ExtendedLagrangeCoeff> {
+    pub fn empty_extended(&self) -> Polynomial<F, ExtendedLagrangeCoeff> {
         Polynomial {
-            values: vec![G::group_zero(); self.extended_len()],
+            values: vec![F::group_zero(); self.extended_len()],
             _marker: PhantomData,
         }
     }
 
     /// Returns a constant polynomial in the extended Lagrange coefficient
     /// basis
-    pub fn constant_extended(&self, scalar: G) -> Polynomial<G, ExtendedLagrangeCoeff> {
+    pub fn constant_extended(&self, scalar: F) -> Polynomial<F, ExtendedLagrangeCoeff> {
         Polynomial {
             values: vec![scalar; self.extended_len()],
             _marker: PhantomData,
@@ -295,11 +355,16 @@ impl<G: Group> EvaluationDomain<G> {
     ///
     /// This function will panic if the provided vector is not the correct
     /// length.
-    pub fn lagrange_to_coeff(&self, mut a: Polynomial<G, LagrangeCoeff>) -> Polynomial<G, Coeff> {
+    pub fn lagrange_to_coeff(&self, mut a: Polynomial<F, LagrangeCoeff>) -> Polynomial<F, Coeff> {
         assert_eq!(a.values.len(), 1 << self.k);
 
         // Perform inverse FFT to obtain the polynomial in coefficient form
-        Self::ifft(&mut a.values, self.omega_inv, self.k, self.ifft_divisor);
+        Self::ifft(
+            &mut a.values,
+            &self.evaluation_helper.fft_data,
+            true,
+            self.ifft_divisor,
+        );
 
         Polynomial {
             values: a.values,
@@ -311,13 +376,13 @@ impl<G: Group> EvaluationDomain<G> {
     /// evaluation domain, rotating by `rotation` if desired.
     pub fn coeff_to_extended(
         &self,
-        mut a: Polynomial<G, Coeff>,
-    ) -> Polynomial<G, ExtendedLagrangeCoeff> {
+        mut a: Polynomial<F, Coeff>,
+    ) -> Polynomial<F, ExtendedLagrangeCoeff> {
         assert_eq!(a.values.len(), 1 << self.k);
 
         self.distribute_powers_zeta(&mut a.values, true);
-        a.values.resize(self.extended_len(), G::group_zero());
-        best_fft(&mut a.values, self.extended_omega, self.extended_k);
+        a.values.resize(self.extended_len(), F::group_zero());
+        best_fft(&mut a.values, &self.evaluation_helper.ext_fft_data, false);
 
         Polynomial {
             values: a.values,
@@ -328,9 +393,9 @@ impl<G: Group> EvaluationDomain<G> {
     /// Rotate the extended domain polynomial over the original domain.
     pub fn rotate_extended(
         &self,
-        poly: &Polynomial<G, ExtendedLagrangeCoeff>,
+        poly: &Polynomial<F, ExtendedLagrangeCoeff>,
         rotation: Rotation,
-    ) -> Polynomial<G, ExtendedLagrangeCoeff> {
+    ) -> Polynomial<F, ExtendedLagrangeCoeff> {
         let new_rotation = ((1 << (self.extended_k - self.k)) * rotation.0.abs()) as usize;
 
         let mut poly = poly.clone();
@@ -350,14 +415,14 @@ impl<G: Group> EvaluationDomain<G> {
     /// This function will panic if the provided vector is not the correct
     /// length.
     // TODO/FIXME: caller should be responsible for truncating
-    pub fn extended_to_coeff(&self, mut a: Polynomial<G, ExtendedLagrangeCoeff>) -> Vec<G> {
+    pub fn extended_to_coeff(&self, mut a: Polynomial<F, ExtendedLagrangeCoeff>) -> Vec<F> {
         assert_eq!(a.values.len(), self.extended_len());
 
         // Inverse FFT
         Self::ifft(
             &mut a.values,
-            self.extended_omega_inv,
-            self.extended_k,
+            &self.evaluation_helper.ext_fft_data,
+            true,
             self.extended_ifft_divisor,
         );
 
@@ -378,8 +443,8 @@ impl<G: Group> EvaluationDomain<G> {
     /// polynomial of the $2^k$ size domain.
     pub fn divide_by_vanishing_poly(
         &self,
-        mut a: Polynomial<G, ExtendedLagrangeCoeff>,
-    ) -> Polynomial<G, ExtendedLagrangeCoeff> {
+        mut a: Polynomial<F, ExtendedLagrangeCoeff>,
+    ) -> Polynomial<F, ExtendedLagrangeCoeff> {
         assert_eq!(a.values.len(), self.extended_len());
 
         // Divide to obtain the quotient polynomial in the coset evaluation
@@ -404,7 +469,7 @@ impl<G: Group> EvaluationDomain<G> {
     ///
     /// `into_coset` should be set to `true` when moving into the coset,
     /// and `false` when moving out. This toggles the choice of `zeta`.
-    fn distribute_powers_zeta(&self, a: &mut [G], into_coset: bool) {
+    fn distribute_powers_zeta(&self, a: &mut [F], into_coset: bool) {
         let coset_powers = if into_coset {
             [self.g_coset, self.g_coset_inv]
         } else {
@@ -422,8 +487,8 @@ impl<G: Group> EvaluationDomain<G> {
         });
     }
 
-    fn ifft(a: &mut [G], omega_inv: G::Scalar, log_n: u32, divisor: G::Scalar) {
-        best_fft(a, omega_inv, log_n);
+    fn ifft(a: &mut [F], fft_data: &FFTData<F>, is_inv: bool, divisor: F) {
+        best_fft(a, &fft_data, is_inv);
         parallelize(a, |a, _| {
             for a in a {
                 // Finish iFFT
@@ -438,24 +503,24 @@ impl<G: Group> EvaluationDomain<G> {
     }
 
     /// Get $\omega$, the generator of the $2^k$ order multiplicative subgroup.
-    pub fn get_omega(&self) -> G::Scalar {
+    pub fn get_omega(&self) -> F {
         self.omega
     }
 
     /// Get $\omega^{-1}$, the inverse of the generator of the $2^k$ order
     /// multiplicative subgroup.
-    pub fn get_omega_inv(&self) -> G::Scalar {
+    pub fn get_omega_inv(&self) -> F {
         self.omega_inv
     }
 
     /// Get the generator of the extended domain's multiplicative subgroup.
-    pub fn get_extended_omega(&self) -> G::Scalar {
+    pub fn get_extended_omega(&self) -> F {
         self.extended_omega
     }
 
     /// Multiplies a value by some power of $\omega$, essentially rotating over
     /// the domain.
-    pub fn rotate_omega(&self, value: G::Scalar, rotation: Rotation) -> G::Scalar {
+    pub fn rotate_omega(&self, value: F, rotation: Rotation) -> F {
         let mut point = value;
         if rotation.0 >= 0 {
             point *= &self.get_omega().pow_vartime(&[rotation.0 as u64]);
@@ -496,23 +561,23 @@ impl<G: Group> EvaluationDomain<G> {
     /// which is the barycentric weight of $\omega^i$.
     pub fn l_i_range<I: IntoIterator<Item = i32> + Clone>(
         &self,
-        x: G::Scalar,
-        xn: G::Scalar,
+        x: F,
+        xn: F,
         rotations: I,
-    ) -> Vec<G::Scalar> {
+    ) -> Vec<F> {
         let mut results;
         {
             let rotations = rotations.clone().into_iter();
             results = Vec::with_capacity(rotations.size_hint().1.unwrap_or(0));
             for rotation in rotations {
                 let rotation = Rotation(rotation);
-                let result = x - self.rotate_omega(G::Scalar::one(), rotation);
+                let result = x - self.rotate_omega(F::Scalar::one(), rotation);
                 results.push(result);
             }
             results.iter_mut().batch_invert();
         }
 
-        let common = (xn - G::Scalar::one()) * self.barycentric_weight;
+        let common = (xn - F::Scalar::one()) * self.barycentric_weight;
         for (rotation, result) in rotations.into_iter().zip(results.iter_mut()) {
             let rotation = Rotation(rotation);
             *result = self.rotate_omega(*result * common, rotation);
@@ -529,7 +594,7 @@ impl<G: Group> EvaluationDomain<G> {
     /// Obtain a pinned version of this evaluation domain; a structure with the
     /// minimal parameters needed to determine the rest of the evaluation
     /// domain.
-    pub fn pinned(&self) -> PinnedEvaluationDomain<'_, G> {
+    pub fn pinned(&self) -> PinnedEvaluationDomain<'_, F> {
         PinnedEvaluationDomain {
             k: &self.k,
             extended_k: &self.extended_k,
@@ -541,10 +606,10 @@ impl<G: Group> EvaluationDomain<G> {
 /// Represents the minimal parameters that determine an `EvaluationDomain`.
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct PinnedEvaluationDomain<'a, G: Group> {
+pub struct PinnedEvaluationDomain<'a, F: Field> {
     k: &'a u32,
     extended_k: &'a u32,
-    omega: &'a G::Scalar,
+    omega: &'a F,
 }
 
 #[test]

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -11,7 +11,7 @@ use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
 use group::ff::{BatchInvert, Field, PrimeField};
 
-use std::{marker::PhantomData, os::unix::prelude::FileExt};
+use std::marker::PhantomData;
 
 /// This structure hold the twiddles and radix for each layer
 #[derive(Debug)]
@@ -488,7 +488,7 @@ impl<F: FieldExt> EvaluationDomain<F> {
     }
 
     fn ifft(a: &mut [F], fft_data: &FFTData<F>, is_inv: bool, divisor: F) {
-        best_fft(a, &fft_data, is_inv);
+        best_fft(a, fft_data, is_inv);
         parallelize(a, |a, _| {
             for a in a {
                 // Finish iFFT


### PR DESCRIPTION
# FFT Optimization
- precompute
   - bit reversed indexes
   - twiddle factor
   - radix for each layer
- reduction
   - bottom butterfly arithmetic multiplicative by exp(0) twiddle
   - recursion tree depth with radix 4 butterfly arithmetic
   - butterfly arithmetic multiplicative by same exp with intermediate value

# Memo
## Recursive or Repeat
In terms of recursion version, the more higher k, the more it took exponentially time.
When we use `repeat` version, we need to rearrange the elements according to bit reverse but it's inefficient.
Now this uses precomputed bit reverse indexes.
The multicore `join` is faster than `scope`.

## Issue
The most expensive part is multiplicative on highest degree.
Now there is no way to reduce highest degree multiplicative.