### PR TITLE
[WIP]parallelize bench

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -57,6 +57,8 @@ criterion = "0.3"
 gumdrop = "0.8"
 proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+ark-std = { version = "0.3", features = ["print-trace"] }
+rand = "0.8"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -2,4 +2,4 @@
 //! `halo2`. It's currently just a (very!) thin wrapper around [`rayon`] but may
 //! be extended in the future to allow for various parallelism strategies.
 
-pub use rayon::{current_num_threads, scope, Scope};
+pub use rayon::{current_num_threads, prelude, scope, Scope};

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -560,7 +560,7 @@ impl<G: Group> EvaluationDomain<G> {
 }
 
 /// recursive butterfly arithmetic
-pub fn recursive_butterfly_arithmetic<G: Group>(
+pub fn recursive_butterfly_arithmetic<G: Group + std::fmt::Debug>(
     a: &mut [G],
     n: usize,
     twiddle_chunk: usize,
@@ -586,7 +586,6 @@ pub fn recursive_butterfly_arithmetic<G: Group>(
                 if i != 0 {
                     t.group_scale(&twiddles[i * twiddle_chunk]);
                 }
-                println!("i: {:?} twiddle_chunk: {:?}", i, twiddle_chunk);
                 *b = *a;
                 a.group_add(&t);
                 b.group_sub(&t);
@@ -661,6 +660,9 @@ fn test_fft() {
 
         let message = format!("recursive fft degree {}", k);
         let start = start_timer!(|| message);
+        indexes
+            .iter()
+            .for_each(|(a, b)| recursive_fft_coeffs.swap(*a, *b));
         recursive_butterfly_arithmetic(&mut recursive_fft_coeffs, n as usize, 1, &twiddles);
         end_timer!(start);
 


### PR DESCRIPTION
I compare `default`, `par_iter` and `join` method fft.

| method  |12|13|14|15|16|17|18|19|
|---|---|---|---|---|---|---|---|---|
|  default |16.792ms|23.639ms|46.421ms|98.337ms|217.202ms|447.500ms|915.478ms|1.818s|
|  par_iter |10.480ms|19.911ms|37.255ms|72.077ms|142.366ms|283.868ms|573.626ms|1.182s|
| join  |8.002ms|16.456ms|32.448ms|70.015ms|137.801ms|276.004ms|538.585ms|1.204s|

`join` version, it uses recursive so try to use smart memory and bench again.
`par_iter` version, it's easy to implement batch and prefetch.

After multiplication optimization

| method  |12|13|14|15|16|17|18|19|
|---|---|---|---|---|---|---|---|---|
|  default | 15.717ms  | 34.789ms  |  55.602ms |113.401ms|217.826ms|447.563ms|939.950ms|1.990s|
|  par_iter |26.746ms|  18.885ms |48.582ms|75.910ms|137.273ms|264.253ms|554.100ms|1.213s|
| join  | 7.371ms  | 33.066ms  |36.197ms|70.194ms|130.423ms|259.156ms|523.820ms|1.133s|

The following is the fastest version `912ms degree = 19` because it avoid multiplication by hardcoding.
https://github.com/appliedzkp/halo2/pull/36#issuecomment-1088402067