### PR TITLE
General Optimization

### DIFF
--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -2,4 +2,4 @@
 //! `halo2`. It's currently just a (very!) thin wrapper around [`rayon`] but may
 //! be extended in the future to allow for various parallelism strategies.
 
-pub use rayon::{current_num_threads, scope, Scope};
+pub use rayon::{current_num_threads, prelude, scope, Scope};

--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -2,4 +2,4 @@
 //! `halo2`. It's currently just a (very!) thin wrapper around [`rayon`] but may
 //! be extended in the future to allow for various parallelism strategies.
 
-pub use rayon::{current_num_threads, prelude, scope, Scope};
+pub use rayon::{current_num_threads, join, prelude, scope, Scope};


### PR DESCRIPTION
# Fft Optimization
Hi there.
I optimized `best_fft` algorithm and replaced with more efficient `rayon` method.

## What I did
`n` = 2^k
### precompute twiddle factors
To precompute the `twiddle factors`, reuse them and it reduced `n` times multiplication.

### avoid multiplication when twiddle factor = 1
Prepare specific case when twiddle factor = 1.
To avoid unnecessary `twiddle factor * element` and it reduced `2n` times multiplication.
It slowed down when I implement it as `if` condition so I hardcode that case.

### `scope` to `par_iter`
Replace `scope` with `par_iter`.
The official document says that the `par_iter` is the most efficient basically.
https://docs.rs/rayon/latest/rayon/#how-to-use-rayon
I benched them and the speed is the `scope > par_iter > join` but the `join` uses a lot of memory.
https://github.com/appliedzkp/halo2/pull/55#issue-1195660345

### other
Avoid `unshuffle` and multiple times bit reverse, it reduced `n` times substitution.
Merge `serial_fft`, `parallel_fft` and `log2_floor` to one function.

## Bench
The `prover` has a [bottleneck](https://github.com/appliedzkp/halo2/pull/36#issuecomment-1085456038) so it doesn't reduce time so much.
|k = `16`|keygen|prover|verifier|
|---|---|---|---|
|default|77.531 s 77.569 s 77.615 s|13.259 s 13.278 s 13.297 s|384.52 ms 384.98 ms 385.71 ms|
|fft|63.543 s 63.631 s 63.764 s|13.015 s 13.025 s 13.035 s|210.18 ms 210.40 ms 210.67 ms|

I would appreciate it if you would confirm.
Thank you.

# Poly Arithmetic Optimization

## What I did

### recursive version
I compared the parallelize method and the `join` is the most efficient because it allocates stack memory.
https://github.com/appliedzkp/halo2/pull/55#issue-1195660345
It seems that the `par_iter` takes some overhead so I change `scope` to `join`.

## Bench
|k = 16|key generation|generate proof|verify proof|
| ---- | ---- | ---- | ---- |
|Default|114.67 s 114.83 s 115.01 s|6.9318 s 6.9437 s 6.9561 s|5.1995 ms 5.2056 ms 5.2121 ms|
|Fft|102.65 s 103.44 s 104.45 s|7.0433 s 7.0947 s 7.1491 s|5.6214 ms 5.6660 ms 5.7189 ms|
|Optimise compute_innter_product|96.803 s 96.907 s 97.021 s|6.4830 s 6.5034 s 6.5222 s|5.1653 ms 5.1706 ms 5.1761 ms|
|Recursive arithmetic|83.920 s 83.975 s 84.023 s|6.0633 s 6.0762 s 6.0894 s|4.9395 ms 4.9592 ms 4.9889 ms|