### PR TITLE
opt: speed up unsafe_setup

### DIFF
--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -86,9 +86,10 @@ impl<C: CurveAffine> Params<C> {
         for _ in k..E::Scalar::S {
             root = root.square();
         }
-        let n_inv = E::Scalar::from(n).invert().expect("inversion should be ok for n = 1<<k");
-        let multiplier =
-            (s.pow_vartime(&[n as u64]) - E::Scalar::one()) * n_inv;
+        let n_inv = E::Scalar::from(n)
+            .invert()
+            .expect("inversion should be ok for n = 1<<k");
+        let multiplier = (s.pow_vartime(&[n as u64]) - E::Scalar::one()) * n_inv;
         parallelize(&mut g_lagrange_projective, |g, start| {
             for (idx, g) in g.iter_mut().enumerate() {
                 let offset = start + idx;

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -86,8 +86,9 @@ impl<C: CurveAffine> Params<C> {
         for _ in k..E::Scalar::S {
             root = root.square();
         }
+        let n_inv = E::Scalar::from(n).invert().expect("inversion should be ok for n = 1<<k");
         let multiplier =
-            (s.pow_vartime(&[n as u64]) - E::Scalar::one()) * E::Scalar::from(n).invert().unwrap();
+            (s.pow_vartime(&[n as u64]) - E::Scalar::one()) * n_inv;
         parallelize(&mut g_lagrange_projective, |g, start| {
             for (idx, g) in g.iter_mut().enumerate() {
                 let offset = start + idx;

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -86,8 +86,7 @@ impl<C: CurveAffine> Params<C> {
         for _ in k..E::Scalar::S {
             root = root.square();
         }
-        let n_inv = E::Scalar::from(n)
-            .invert()
+        let n_inv = Option::<E::Scalar>::from(E::Scalar::from(n).invert())
             .expect("inversion should be ok for n = 1<<k");
         let multiplier = (s.pow_vartime(&[n as u64]) - E::Scalar::one()) * n_inv;
         parallelize(&mut g_lagrange_projective, |g, start| {


### PR DESCRIPTION
since we know `s` here, we don't need to do ifft. Directly computing lagranges is much faster.

for k = 16, reduce setup time from 40s to 4s